### PR TITLE
feat: support follow system theme in theme toggle

### DIFF
--- a/lib/screens/widgets/settings/theme_toggle_button.dart
+++ b/lib/screens/widgets/settings/theme_toggle_button.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:running_services_monitor/core/dependency_injection/dependency_injection.dart';
 import 'package:running_services_monitor/core/extensions.dart';
 import 'package:running_services_monitor/core/theme/theme_bloc.dart';
 
-class ThemeToggleButton extends StatefulWidget {
+class ThemeToggleButton extends StatelessWidget {
   const ThemeToggleButton({super.key});
 
-  @override
-  State<ThemeToggleButton> createState() => _ThemeToggleButtonState();
-}
-
-class _ThemeToggleButtonState extends State<ThemeToggleButton> {
   AppThemeMode getNextThemeMode(AppThemeMode themeMode, Brightness brightness) {
     switch (themeMode) {
       case AppThemeMode.light:
@@ -28,27 +24,29 @@ class _ThemeToggleButtonState extends State<ThemeToggleButton> {
     }
   }
 
-  void onPressed(Brightness brightness) {
-    setState(() {
-      final themeMode = getIt<ThemeBloc>().state;
-      final newThemeMode = getNextThemeMode(themeMode, brightness);
-      getIt<ThemeBloc>().add(ThemeEvent.setTheme(mode: newThemeMode));
-    });
+  void onPressed(AppThemeMode themeMode, Brightness brightness) {
+    final newThemeMode = getNextThemeMode(themeMode, brightness);
+    getIt<ThemeBloc>().add(ThemeEvent.setTheme(mode: newThemeMode));
   }
 
   @override
   Widget build(BuildContext context) {
-    final brightness = MediaQuery.platformBrightnessOf(context);
-    final themeMode = getIt<ThemeBloc>().state;
-    final icon = switch (themeMode) {
-      AppThemeMode.light => const Icon(Icons.light_mode),
-      AppThemeMode.dark => const Icon(Icons.dark_mode),
-      _ => const Icon(Icons.brightness_auto),
-    };
-    return IconButton(
-      icon: icon,
-      onPressed: () => onPressed(brightness),
-      tooltip: context.loc.toggleTheme,
+    return BlocSelector<ThemeBloc, AppThemeMode, AppThemeMode>(
+      bloc: getIt<ThemeBloc>(),
+      selector: (state) => state,
+      builder: (context, themeMode) {
+        final brightness = MediaQuery.platformBrightnessOf(context);
+        final icon = switch (themeMode) {
+          AppThemeMode.light => const Icon(Icons.light_mode),
+          AppThemeMode.dark => const Icon(Icons.dark_mode),
+          _ => const Icon(Icons.brightness_auto),
+        };
+        return IconButton(
+          icon: icon,
+          onPressed: () => onPressed(themeMode, brightness),
+          tooltip: context.loc.toggleTheme,
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
Added `Follow System` option on theme toggle button, allowing the app theme to automatically follow the system theme mode.

> **Light Mode**: `system -> light -> dark -> system -> light -> ...`
> **Dark Mode**: `system -> dart -> light -> system -> dark -> ...`

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4aad8e6c-9bcf-46f4-a23e-e16c7b54d727" />
